### PR TITLE
Exposes `clickableIcons` to control clicks on points-of-interest (POIs).

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ export default Ember.Route.extend({
       lng: -86.8025,
       mapType: 'satellite', // Accepts 'roadmap', 'satellite', 'hybrid', or 'terrain'
       showMapTypeControl: true,
+      clickableIcons: true,
       draggable: true,
       disableDefaultUI: false,
       disableDoubleClickZoom: false,
@@ -445,6 +446,10 @@ export default Ember.Route.extend({
 
 ```handlebars
 {{g-maps ... disableDefaultUI=true}}
+```
+
+```handlebars
+{{g-maps ... clickableIcons=true}}
 ```
 
 ```handlebars

--- a/addon/mixins/g-maps/core/main.js
+++ b/addon/mixins/g-maps/core/main.js
@@ -11,6 +11,7 @@ export default Ember.Mixin.create(Ember.Evented, {
   zoom: 0,
   mapType: 'ROADMAP',
   showMapTypeControl: true,
+  clickableIcons: true,
   draggable: true,
   disableDefaultUI: false,
   disableDoubleClickZoom: false,
@@ -55,7 +56,8 @@ export default Ember.Mixin.create(Ember.Evented, {
       'showMapTypeControl',
       'scaleControl',
       'showScaleControl',
-      'disableDefaultUI'
+      'disableDefaultUI',
+      'clickableIcons'
     );
 
     // Map symantic names to Google Map Options

--- a/tests/dummy/app/pods/basic-usage/map-properties/template.hbs
+++ b/tests/dummy/app/pods/basic-usage/map-properties/template.hbs
@@ -7,6 +7,7 @@
   <li><a {{action "scrollToId" 'showZoomControl'}}>showZoomControl</a></li>
   <li><a {{action "scrollToId" 'showScaleControl'}}>showScaleControl</a></li>
   <li><a {{action "scrollToId" 'disableDefaultUI'}}>disableDefaultUI</a></li>
+  <li><a {{action "scrollToId" 'clickableIcons'}}>clickableIcons</a></li>
   <li><a {{action "scrollToId" 'disableDoubleClickZoom'}}>disableDoubleClickZoom</a></li>
   <li><a {{action "scrollToId" 'scrollwheel'}}>scrollwheel</a></li>
 </ul>
@@ -345,6 +346,51 @@
                     <tbody><tr>
                       <td id="file-templa-hbs-L1" class="blob-num js-line-number" data-line-number="1"></td>
                       <td id="file-templa-hbs-LC1" class="blob-code blob-code-inner js-file-line"><span class="pl-c1">\{{</span><span class="pl-v">g-maps</span> disableDefaultUI=false<span class="pl-c1">}}</span></td>
+                    </tr>
+                  </tbody></table>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="gist-meta">
+            made with ❤ by <a href="https://github.com">GitHub</a>
+          </div>
+        </div>
+      </div>
+    </code>
+  </div>
+</p>
+
+<hr>
+
+<p id="clickableIcons" class="medium-7">
+  <h3>clickableIcons</h3>
+
+  <div class="-mb">
+    <small class="-db">Type</small>
+    Boolean
+  </div>
+  <div class="-mb">
+    <small class="-db">Default</small>
+    <div class="gmaps-inline-code -nml">true</div>
+  </div>
+  <div class="-mb">
+    <small class="-db">Resources</small>
+    <a href="https://developers.google.com/maps/documentation/javascript/reference#MapOptions" target="_blank">Google Map Options</a>
+  </div>
+  <div class="gmaps-snippet">
+    <header>Example</header>
+    <code>
+      <div class="gist">
+        <div class="gist-file">
+          <div class="gist-data">
+            <div class="js-gist-file-update-container js-task-list-container file-box">
+              <div id="file-templa-hbs" class="file">
+                <div class="blob-wrapper data type-handlebars">
+                  <table class="highlight tab-size js-file-line-container" data-tab-size="8">
+                    <tbody><tr>
+                      <td id="file-templa-hbs-L1" class="blob-num js-line-number" data-line-number="1"></td>
+                      <td id="file-templa-hbs-LC1" class="blob-code blob-code-inner js-file-line"><span class="pl-c1">\{{</span><span class="pl-v">g-maps</span> clickableIcons=false<span class="pl-c1">}}</span></td>
                     </tr>
                   </tbody></table>
                 </div>


### PR DESCRIPTION
This option allows POI icons to be made not clickable.

Example POI:

![](https://screen-caps.s3.amazonaws.com/Wn9V3of93t.png)

And what they look like when they're clicked:

![](https://screen-caps.s3.amazonaws.com/LYk0GAU0UK.png)
