### PR TITLE
Add geolocate method in the service

### DIFF
--- a/addon/services/g-map.js
+++ b/addon/services/g-map.js
@@ -132,7 +132,10 @@ export default Ember.Service.extend({
   },
 
   geolocate(always) {
-    always = typeOf(always) === 'function' ? always : function() {};
+    always = typeOf(always) === 'undefined' ? function() {} : always;
+    if(typeOf(always) !== 'function') {
+      throw new Error('Input argument must be type of function.');
+    }
     return new Ember.RSVP.Promise(function(resolve, reject) {
       let options = {
         success(position) {

--- a/addon/services/g-map.js
+++ b/addon/services/g-map.js
@@ -131,6 +131,25 @@ export default Ember.Service.extend({
     });
   },
 
+  geolocate(always) {
+    always = typeOf(always) === 'function' ? always : function() {};
+    return new Ember.RSVP.Promise(function(resolve, reject) {
+      let options = {
+        success(position) {
+          resolve(position);
+        },
+        error(error) {
+          reject(error);
+        },
+        not_supported() {
+          throw new Error('Your browser does not support geolocation.');
+        },
+        always
+      };
+      GMaps.prototype.utils.geolocate(options);
+    });
+  },
+
   autocompletes: Ember.computed({
     get() {
       let autocompletes = {};

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -110,6 +110,19 @@ export default Ember.Route.extend({
       heatmapOpacity: 1
     });
 
+    this.get('gMap')
+      .geolocate()
+      .then(geolocate => {
+        let marker = {
+          id: 'jdlksadvefajs22',
+          lat: geolocate.coords.latitude,
+          lng: geolocate.coords.longitude,
+          infoWindow: { content: '<p class="-nmb">Are you here</p>', visible: true }
+        };
+        controller.get('markers').addObject(marker);
+      })
+      .catch((err) => console.error(err));
+
     // window.setInterval(() => {
     //   let lat = controller.get('lat')+ 0.5;
     //   controller.set('lat', lat);


### PR DESCRIPTION
Example code:

```
...
gMap: Ember.inject.service(),
yourFunction() {
   /*fires always after every scenario described above*/
   let always = () => {
     console.log('Done!');
   };
   this.get('gMap')
     .geolocate(always /*optional*/)
     .then(geolocate => {
        console.log(geolocate);
     })
     .catch((err) => console.error(err));
}
...
```
