### PR TITLE
Use correct callback for Ember.$.getScript()

### DIFF
--- a/addon/utils/load-google-maps.js
+++ b/addon/utils/load-google-maps.js
@@ -37,7 +37,7 @@ const lazyLoadGoogleMap = (src) => {
 
   return new RSVP.Promise((resolve, reject) => {
     Ember.$.getScript(src)
-      .success(function emberCliGMapsLazyLoadSuccess() {
+      .done(function emberCliGMapsLazyLoadSuccess() {
         resolve(window.google.maps);
       })
       .fail(function emberCliGMapsLazyLoadFailure(jqXhr) {

--- a/tests/unit/utils/load-google-maps-test.js
+++ b/tests/unit/utils/load-google-maps-test.js
@@ -32,7 +32,7 @@ test('`lazyLoadGoogleMap` should reject after failing to fetch Google Maps', (as
   const originalGetScript = Ember.$.getScript;
   const getScriptStub = function () {
     const methods = {
-      success: () => methods,
+      done: () => methods,
       fail: (reject) => {
         reject();
         return methods;
@@ -58,7 +58,7 @@ test('`lazyLoadGoogleMap` should resolve google.maps after successfully fetching
   const originalGetScript = Ember.$.getScript;
   const getScriptStub = function () {
     const methods = {
-      success: (resolve) => {
+      done: (resolve) => {
         resolve();
         return methods;
       },


### PR DESCRIPTION
A nonexistent function "success" is being called on the return value of Ember.$.getScript(). Should be "done".
