### PR TITLE
Use findHost or old ember-cli behavior when looking up for the parent application

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,25 +5,25 @@ module.exports = {
   name: 'ember-cli-g-maps',
 
   // Include Gmaps code in consuming app
-  included: function() {
-    this._super.included(...arguments);
+  included: function(app) {
+    this._super.included(app);
 
-    var app;
+    var host;
 
     // If the addon has the _findHost() method (in ember-cli >= 2.7.0), we'll just
     // use that.
     if (typeof this._findHost === 'function') {
-      app = this._findHost();
+      host = this._findHost();
     } else {
       // Otherwise, we'll use this implementation borrowed from the _findHost()
       // method in ember-cli.
       var current = this;
       do {
-        app = current.app || app;
+        host = current.app || host;
       } while (current.parent.parent && (current = current.parent));
     }
 
-    app.import(app.bowerDirectory + '/gmaps-for-apps/gmaps.js');
+    host.import(app.bowerDirectory + '/gmaps-for-apps/gmaps.js');
   },
 
   // Request Google Maps script in consuming app

--- a/index.js
+++ b/index.js
@@ -1,29 +1,26 @@
 /* jshint node: true */
+/* global process */
 'use strict';
 
 module.exports = {
   name: 'ember-cli-g-maps',
 
-  // Include Gmaps code in consuming app
+  // Import gmaps-for-apps
   included: function(app) {
-    this._super.included(app);
+    this._super.included.apply(this, arguments);
 
-    var host;
-
-    // If the addon has the _findHost() method (in ember-cli >= 2.7.0), we'll just
-    // use that.
-    if (typeof this._findHost === 'function') {
-      host = this._findHost();
-    } else {
-      // Otherwise, we'll use this implementation borrowed from the _findHost()
-      // method in ember-cli.
-      var current = this;
-      do {
-        host = current.app || host;
-      } while (current.parent.parent && (current = current.parent));
+    // see: https://github.com/ember-cli/ember-cli/issues/3718
+    if (typeof app.import !== 'function' && app.app) {
+      app = app.app;
     }
 
-    host.import(app.bowerDirectory + '/gmaps-for-apps/gmaps.js');
+    if (!process.env.EMBER_CLI_FASTBOOT) {
+      if (app.env === 'production') {
+        app.import(app.bowerDirectory + '/gmaps-for-apps/gmaps.min.js');
+      } else {
+        app.import(app.bowerDirectory + '/gmaps-for-apps/gmaps.js');
+      }
+    }
   },
 
   // Request Google Maps script in consuming app

--- a/index.js
+++ b/index.js
@@ -5,8 +5,23 @@ module.exports = {
   name: 'ember-cli-g-maps',
 
   // Include Gmaps code in consuming app
-  included: function(app) {
-    this._super.included(app);
+  included: function() {
+    this._super.included(...arguments);
+
+    var app;
+
+    // If the addon has the _findHost() method (in ember-cli >= 2.7.0), we'll just
+    // use that.
+    if (typeof this._findHost === 'function') {
+      app = this._findHost();
+    } else {
+      // Otherwise, we'll use this implementation borrowed from the _findHost()
+      // method in ember-cli.
+      var current = this;
+      do {
+        app = current.app || app;
+      } while (current.parent.parent && (current = current.parent));
+    }
 
     app.import(app.bowerDirectory + '/gmaps-for-apps/gmaps.js');
   },


### PR DESCRIPTION
Allow the addon to find the ember application when this addon is being used as a dependency of another addon. The lookup is compatible with all versions of ember-cli