### PR TITLE
Use set options when style attribute changes.

### DIFF
--- a/addon/components/g-maps.js
+++ b/addon/components/g-maps.js
@@ -11,6 +11,7 @@ import twoWayZoomControl from 'ember-cli-g-maps/mixins/g-maps/core/two-way-zoom-
 import twoWayScaleControl from 'ember-cli-g-maps/mixins/g-maps/core/two-way-scale-control';
 import twoWayMapType from 'ember-cli-g-maps/mixins/g-maps/core/two-way-map-type';
 import twoWayMapTypeControl from 'ember-cli-g-maps/mixins/g-maps/core/two-way-map-type-control';
+import twoWayStyles from 'ember-cli-g-maps/mixins/g-maps/core/two-way-styles';
 
 // Map Childs //
 import gMapCircles from 'ember-cli-g-maps/mixins/g-maps/circles';
@@ -42,5 +43,6 @@ export default Ember.Component.extend(
   twoWayScaleControl,
   twoWayMapType,
   twoWayMapTypeControl,
+  twoWayStyles,
   coreMain
 );

--- a/addon/mixins/g-maps/core/two-way-styles.js
+++ b/addon/mixins/g-maps/core/two-way-styles.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+
+const { observer } = Ember;
+
+export default Ember.Mixin.create({
+
+  /**
+   * [observer for component attribute's `styles` updates]
+   * @param  {Boolean} 'isMapLoaded'
+   * @param  {[Boolean]}  'styles'
+   * @return {[Boolean]} [returns false if map not updated]
+   */
+  _bindStylesToMap: observer('isMapLoaded', 'styles', function() {
+    if (!this.get('isMapLoaded')) {
+      return false;
+    }
+
+    this.get('map.map').setOptions({
+      styles: this.get('styles')
+    });
+  }),
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-g-maps",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "An Ember CLI Addon for map driven applications",
   "directories": {
     "doc": "doc",

--- a/tests/unit/mixins/g-maps/core/two-way-styles-test.js
+++ b/tests/unit/mixins/g-maps/core/two-way-styles-test.js
@@ -1,0 +1,34 @@
+import Ember from 'ember';
+import twoWayStyleslMixin from 'ember-cli-g-maps/mixins/g-maps/core/two-way-styles';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | g maps/core/two way styles');
+
+test('_bindStylesToMap should not update map if `isMapLoaded` = false', function(assert) {
+  const twoWayStylesObject = Ember.Object.extend(twoWayStyleslMixin);
+  const subject = twoWayStylesObject.create();
+
+  subject.setProperties({ showMapTypeControl: false, isMapLoaded: false });
+  assert.equal(subject._bindStylesToMap(), false, 'should return false if cannot sync');
+});
+
+test('_bindStylesToMap observer should update map if `isMapLoaded` = true', function(assert) {
+  assert.expect(1);
+
+  const twoWayStylesObject = Ember.Object.extend(twoWayStyleslMixin);
+  const subject = twoWayStylesObject.create();
+
+  subject.setProperties({
+    styles: {},
+    isMapLoaded: false,
+    map: {
+      map: {
+        setOptions: function(option) {
+          assert.equal(option.styles, subject.get('styles'), 'should recieve `subject.styles`');
+        }
+      }
+    }
+  });
+
+  subject.set('isMapLoaded', true);
+});


### PR DESCRIPTION
Fixes #71 

This change allows the user to dynamically set the styles property on the component. 

One thing to note is the test just checks for the existence of the styles object. I can add a style to the test, but that would add a lot of extra code to the test.