### PR TITLE
Hotfix/fix documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-g-maps",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "An Ember CLI Addon for map driven applications",
   "directories": {
     "doc": "doc",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -37,7 +37,7 @@ module.exports = function(environment) {
 
   ENV.googleMap = {
     libraries: ['drawing', 'visualization', 'places'],
-    lazyLoad: true
+    lazyLoad: false
   };
 
   if (environment === 'development') {


### PR DESCRIPTION
Some documentation routes rely on direct access to the google.maps object.  Remove lazy loading to prevent ReferenceError